### PR TITLE
Force autostart of documentserver-example

### DIFF
--- a/after-run.sh
+++ b/after-run.sh
@@ -5,6 +5,7 @@ docker exec -it doc-linux json -f /etc/onlyoffice/documentserver/default.json -I
 docker exec -it doc-linux json -f /etc/onlyoffice/documentserver/default.json -I -e 'this.services.CoAuthoring.autoAssembly.enable=true'
 
 docker exec -it doc-linux sed -i 's/WARN/ALL/g' /etc/onlyoffice/documentserver/log4js/production.json
+docker exec -it doc-linux sed 's,autostart=false,autostart=true,' -i /etc/supervisor/conf.d/onlyoffice-documentserver-example.conf
 docker exec -it doc-linux supervisorctl restart all
 docker cp archive-share-libs.sh doc-linux:/tmp/archive-share-libs.sh
 docker exec -it doc-linux bash /tmp/archive-share-libs.sh


### PR DESCRIPTION
logrotate enabled - supervisor service is restarted once a day
but `onlyoffice-documentserver:example` service is not in autostart, so it staed stopped
since:
https://github.com/ONLYOFFICE/document-server-package/commit/6e698e29cf5e3d5a6ff4f1b69360b4154cd85c8d