### PR TITLE
Remove archive of libs after service start

### DIFF
--- a/after-run.sh
+++ b/after-run.sh
@@ -7,6 +7,4 @@ docker exec -it doc-linux /var/www/onlyoffice/documentserver/npm/node_modules/.b
 docker exec -it doc-linux sed -i 's/WARN/ALL/g' /etc/onlyoffice/documentserver/log4js/production.json
 docker exec -it doc-linux sed 's,autostart=false,autostart=true,' -i /etc/supervisor/conf.d/ds-example.conf
 docker exec -it doc-linux supervisorctl restart all
-docker cp archive-share-libs.sh doc-linux:/tmp/archive-share-libs.sh
-docker exec -it doc-linux bash /tmp/archive-share-libs.sh
 docker exec -it doc-linux dpkg-query --showformat='${Version}\n' --show onlyoffice-documentserver-ie

--- a/archive-share-libs.sh
+++ b/archive-share-libs.sh
@@ -1,2 +1,0 @@
-tar -cvf /var/www/onlyoffice/documentserver-example/public/libs.tar --directory="/var/www/onlyoffice/documentserver/server/FileConverter/bin" .
-echo "Show all libs and x2t in doc-linux.teamlab.info/example/libs.tar"


### PR DESCRIPTION
@flaminestone said he not use it any more,
so it's safe to remove this feature