### PR TITLE
Add ability to log all access logs

### DIFF
--- a/after-run.sh
+++ b/after-run.sh
@@ -7,5 +7,7 @@ docker exec -it doc-linux $JSON_EXE -f /etc/onlyoffice/documentserver/default.js
 
 docker exec -it doc-linux sed -i 's/WARN/ALL/g' /etc/onlyoffice/documentserver/log4js/production.json
 docker exec -it doc-linux sed 's,autostart=false,autostart=true,' -i /etc/supervisor/conf.d/ds-example.conf
+docker exec -it doc-linux sed -i 's,access_log off,access_log /var/log/onlyoffice/documentserver/nginx.access.log,' /etc/onlyoffice/documentserver/nginx/includes/ds-common.conf
+docere exec -it doc-linux service nginx restart
 docker exec -it doc-linux supervisorctl restart all
 docker exec -it doc-linux dpkg-query --showformat='${Version}\n' --show onlyoffice-documentserver-ie


### PR DESCRIPTION
Those additional logs needed to debug messages like:
```
"https://doc-linux.teamlab.info/5.5.4-11/spellchecker/doc/b53aR08NsYK7ApjVJ_QzcGmOH2m_LI_Joc797a65Cqc_/c/029/5xu30t13/jsonp?c=_jp.afiddwd - Failed to load resource: the server responded with a status of 500 ()"
```